### PR TITLE
まいなーちぇんじ

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@ Version 0.8.0
 ## Get started
 
 1. Download akerun-log.php
-2. Edit `AKERUNLOG_CACHE_DIR`
-3. Call them from `include`
-4. Instantiate class and save to your favorite variable with options for your needs
-5. Access object!!
+2. Call them from `include`
+3. Instantiate class and save to your favorite variable with options for your needs
+4. Access object!!
 
 ## Example
 
@@ -139,9 +138,6 @@ It will automatically set maximum API request interval allowed in accordance to 
 - - - - - - - - - - - - - - - - - -
 
 ## Upcoming features
-
-- Easier cache file directory configuration
-	- I am currently too lazy, but this will be updated, such as using `__dir__` as a default for the parent for the cache directory.
 
 - Saving Daily logs (version 2?)
 	- Currently this doesn't really support caching on daily basis, but instead it only keeps the newest cache for the last 24 hours by default.

--- a/akerun-log.php
+++ b/akerun-log.php
@@ -7,7 +7,7 @@
 	- - - - - - - - - - - - - - - - - - */
 // Config
 // * Last slash after directory name must be omitted
-define('AKERUNLOG_CACHE_DIR', ROOT_SRV_PATH.'akerun_cache');
+define('AKERUNLOG_CACHE_DIR', dirname(__FILE__).'/akerunlog_cache');
 define('AKERUNLOG_CACHE_FILENAME', 'cache.json');
 define('AKERUNLOG_CACHE_FILEPATH', AKERUNLOG_CACHE_DIR.'/'.AKERUNLOG_CACHE_FILENAME);
 class AkerunLog {

--- a/akerun-log.php
+++ b/akerun-log.php
@@ -13,10 +13,11 @@ define('AKERUNLOG_CACHE_FILEPATH', AKERUNLOG_CACHE_DIR.'/'.AKERUNLOG_CACHE_FILEN
 class AkerunLog {
 	// Outputs (per single instance)
 	public $data; // Raw data (JSON from API Call to PHP Array, plus some metadata about execution process)
+	public $name;
 	protected $pid = 0;
 	protected $total_requests = 0;
 	// Outputs (shared across instances)
-	protected static $exec_err_log = array();
+	public static $exec_err_log = array();
 	protected static $data_cache = array ();
 	/*
 	$data_cache = array(


### PR DESCRIPTION
エラーログみやすくした
ログファイルのディレクトリ勝手に適当にしてくれるようにした（akerun-log.php と同じディレクトリにakerunlog_cache ディレクトリができる）